### PR TITLE
change namespace of logdna-agent-key

### DIFF
--- a/04-observability/log.tf
+++ b/04-observability/log.tf
@@ -12,7 +12,8 @@
 
 resource kubernetes_secret logdna_agent_key {
   metadata {
-    name = "logdna-agent-key"
+    name = "logdna-agent-key",
+    namespace = "${var.log_mon_ns}"
   }
 
   data = {


### PR DESCRIPTION
logdna-agent-key will be created by default at default namespace. Change to create on designated namespace ie ibm-observe